### PR TITLE
Implements MDC-Switch Component

### DIFF
--- a/addon/components/mdc-switch.js
+++ b/addon/components/mdc-switch.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+import layout from '../templates/components/mdc-switch';
+
+const { get } = Ember;
+
+export default Ember.Component.extend({
+  //region Attributes
+  /**
+   * This property is considered read-only by the component, and will not be
+   * updated by user action. Please see `onchange` to handle user actions.
+   * @type {Boolean}
+   */
+  checked: false,
+  /**
+   * @type {Boolean}
+   */
+  disabled: false,
+  /**
+   * This will be called when the user indicates they want to change the value
+   * of the switch. If you want to simulate two-way binding, you can use the
+   * switch like this:
+   *
+   * {{mdc-switch checked=(eq switchValue "one") onchange=(action "setSwitchValue" "one")}}
+   *
+   * @type {Function}
+   * @param {Boolean} checked
+   */
+  onchange: x => x,
+  /**
+   * @type {?String}
+   */
+  'input-id': null,
+  //endregion
+
+  //region Ember Hooks
+  layout,
+  classNames: 'mdc-switch',
+  classNameBindings: ['disabled:mdc-switch--disabled'],
+  attributeBindings: ['disabled'],
+  //endregion
+
+  //region Actions
+  actions: {
+    inputChanged(ev) {
+      const checked = ev.target.checked;
+      get(this, 'onchange')(checked);
+    }
+  }
+  //endregion
+});

--- a/addon/templates/components/mdc-switch.hbs
+++ b/addon/templates/components/mdc-switch.hbs
@@ -1,0 +1,4 @@
+<input type="checkbox" id={{input-id}} onchange={{action "inputChanged"}} class="mdc-switch__native-control" disabled={{disabled}} />
+<div class="mdc-switch__background">
+  <div class="mdc-switch__knob"></div>
+</div>

--- a/app/components/mdc-switch.js
+++ b/app/components/mdc-switch.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-material-components-web/components/mdc-switch';

--- a/blueprints/ember-material-components-web/index.js
+++ b/blueprints/ember-material-components-web/index.js
@@ -19,7 +19,8 @@ module.exports = {
       { name: '@material/toolbar', target: '0.4.1'},
       { name: '@material/tabs', target: '0.1.1'},
       { name: '@material/ripple', target: '0.7.0'},
-      { name: '@material/linear-progress', target: '0.1.3'}
+      { name: '@material/linear-progress', target: '0.1.3'},
+      { name: '@material/switch', target: '0.1.12'}
     ]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ var materialPackages = [
   { name: '@material/toolbar', css: true, js: true },
   { name: '@material/tabs', css: true, js: true },
   { name: '@material/ripple', css: true, js: true },
-  { name: '@material/linear-progress', css: true, js: true }
+  { name: '@material/linear-progress', css: true, js: true },
+  { name: '@material/switch', css: true, js: false }
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@material/list": "0.1.0",
     "@material/menu": "0.4.0",
     "@material/radio": "0.2.5",
+    "@material/switch": "0.1.12",
     "@material/ripple": "0.7.0",
     "@material/tabs": "0.1.1",
     "@material/textfield": "0.2.0",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -278,6 +278,19 @@
   {{outlet}}
 </section>
 
+<section class="component-doc">
+  <h2 class="mdc-typography--title">Switch</h2>
+  <h3 class="mdc-typography--subheading2">Active Switch</h3>
+  {{mdc-switch checked=isFirstSwitchOn onchange=(action (mut isFirstSwitchOn))}}
+  <h3 class="mdc-typography--subheading2">Switch with Toggle Label</h3>
+  <label>
+    {{mdc-switch checked=isSecondSwitchOn onchange=(action (mut isSecondSwitchOn))}}
+    On/Off
+  </label>
+  <h3 class="mdc-typography--subheading2">Disabled Switch</h3>
+  {{mdc-switch disabled=true}}
+</section>
+
 {{/if}}
 
 {{#mdc-button class="toggle-demo-visibility" click=(action (toggle "isDemoVisible" this))}}Toggle visibility{{/mdc-button}}

--- a/tests/integration/components/mdc-switch-test.js
+++ b/tests/integration/components/mdc-switch-test.js
@@ -1,0 +1,21 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('mdc-switch', 'Integration | Component | mdc switch', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{mdc-switch}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`{{mdc-switch}}`);
+
+  assert.equal(this.$().text().trim(), '');
+});


### PR DESCRIPTION
Material Design Switch component is now available for use in Ember Material Components Web. This component functions very similarly to the checkbox component. Example implementations:

To simulate two-way binding:
`{{mdc-switch checked=isSwitchOn onchange=(action (mut isSwitchOn))}}`

To include a label, wrap the component in a label tag:
```
<label>
  {{mdc-switch checked=isSecondSwitchOn onchange=(action (mut isSecondSwitchOn))}}
  On/Off
</label>
```

Disabled state:
`{{mdc-switch disabled=true}}`

![screen shot 2017-08-25 at 4 34 20 pm](https://user-images.githubusercontent.com/20466869/29734197-7bded45c-89b6-11e7-9a04-a9db7038dc72.png)
