### PR TITLE
:sparkles: Dark theme can be used for tab bars and tab bar scrollers

### DIFF
--- a/addon/components/mdc-tab-bar-scroller.js
+++ b/addon/components/mdc-tab-bar-scroller.js
@@ -11,8 +11,17 @@ const { get, computed, set, run } = Ember;
 const { cssClasses, strings } = MDCTabBarScrollerFoundation;
 
 export default Ember.Component.extend(MDCComponent, {
+  //region Attributes
+  /**
+   * Pass as true for white text on a darker background
+   * @type {Boolean}
+   */
+  dark: false,
+  //endregion
+
   //region Ember Hooks
   classNames: ['mdc-tab-bar-scroller'],
+  classNameBindings: ['dark:mdc-theme--dark'],
   layout,
   init() {
     this._super(...arguments);

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -21,6 +21,11 @@ export default Ember.Component.extend(MDCComponent, {
    */
   icons: null,
   /**
+   * Pass as true for white text on a darker background
+   * @type {Boolean}
+   */
+  dark: false,
+  /**
    * @type {String}
    */
   'additional-indicator-classes': '',
@@ -42,7 +47,7 @@ export default Ember.Component.extend(MDCComponent, {
   //region Ember Hooks
   layout,
   classNames: ['mdc-tab-bar'],
-  classNameBindings: ['isIconsOnly:mdc-tab-bar--icon-tab-bar', 'isIconsWithText:mdc-tab-bar--icons-with-text', 'mdcClassNames'],
+  classNameBindings: ['isIconsOnly:mdc-tab-bar--icon-tab-bar', 'isIconsWithText:mdc-tab-bar--icons-with-text', 'mdcClassNames', 'dark:mdc-theme--dark'],
   attributeBindings: ['style'],
   init() {
     this._super(...arguments);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -310,6 +310,21 @@
     {{/scroller.tab-bar}}
   {{/mdc-tab-bar-scroller}}
 
+  <h3 class="mdc-typography--subheading2">Dark-themed tabs</h3>
+  <div style="background:black">
+    {{#mdc-tab-bar dark=true links=false as |bar|}}
+      {{#bar.tab active=isFirstActive become-active=(action (mut isFirstActive))}}
+        Fruits
+      {{/bar.tab}}
+      {{#bar.tab active=isSecondActive become-active=(action (mut isSecondActive))}}
+        Vegetables
+      {{/bar.tab}}
+      {{#bar.tab active=isThirdActive become-active=(action (mut isThirdActive))}}
+        Meats
+      {{/bar.tab}}
+    {{/mdc-tab-bar}}
+  </div>
+
   {{outlet}}
 </section>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,10 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.3.0.tgz#57b13c75e705eba9686ec5e9fd03a361738ce76a"
 
+"@material/animation@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.3.1.tgz#229de6927d0590d6d6b20157d778d264ef02229a"
+
 "@material/base@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.1.0.tgz#aae23050425f3c8d2b67b370ffc667dc042db352"
@@ -67,6 +71,12 @@
   resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-0.1.10.tgz#f0250c97c81663534b83c3428e764c9026d41ba1"
   dependencies:
     "@material/animation" "^0.3.0"
+
+"@material/elevation@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-0.1.11.tgz#195815648697f2fbad20666a4c232dc9b6f1189b"
+  dependencies:
+    "@material/animation" "^0.3.1"
 
 "@material/fab@0.3.9":
   version "0.3.9"
@@ -154,6 +164,14 @@
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.1.7.tgz#b38b771af183bcf34d643f600f17fc433698535a"
 
+"@material/switch@0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-0.1.12.tgz#ec41cf737567f503b63c620f6124646a202a548f"
+  dependencies:
+    "@material/animation" "^0.3.1"
+    "@material/elevation" "^0.1.11"
+    "@material/theme" "^0.2.0"
+
 "@material/tabs@0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@material/tabs/-/tabs-0.2.4.tgz#ddc8ebe7f9aeccdf8dcb296a14c0af2c38d48668"
@@ -182,6 +200,10 @@
 "@material/theme@^0.1.0", "@material/theme@^0.1.1", "@material/theme@^0.1.5", "@material/theme@^0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.1.6.tgz#a2044973590a68f608b439d2ce33c17707bc000c"
+
+"@material/theme@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.2.0.tgz#f54a62e8bcd2a63818419c02f7ec61d9968eff07"
 
 "@material/toolbar@0.4.1":
   version "0.4.1"


### PR DESCRIPTION
Adds a boolean attribute of `dark` to `{{mdc-tab-bar}}` and `{{mdc-tab-bar-scroller}}`. It is set to false by default, but when passed as true it will adjust the styles of the component to be more visible on a darker background. More specifically, it adds the class name of `mdc-theme--dark` to the component, and Google's material design styling does the rest.

Example usage:
```
<div style="background:black">
    {{#mdc-tab-bar dark=true links=false as |bar|}}
      {{#bar.tab active=isFirstActive become-active=(action (mut isFirstActive))}}
        Fruits
      {{/bar.tab}}
      {{#bar.tab active=isSecondActive become-active=(action (mut isSecondActive))}}
        Vegetables
      {{/bar.tab}}
      {{#bar.tab active=isThirdActive become-active=(action (mut isThirdActive))}}
        Meats
      {{/bar.tab}}
    {{/mdc-tab-bar}}
 </div>
```