### PR TITLE
Checked attribute for binary state components

### DIFF
--- a/addon/templates/components/mdc-checkbox.hbs
+++ b/addon/templates/components/mdc-checkbox.hbs
@@ -1,4 +1,4 @@
-<input type="checkbox" onclick={{action "clicked"}} id={{input-id}} name={{name}} onchange={{action "inputChanged"}} class="mdc-checkbox__native-control">
+<input type="checkbox" onclick={{action "clicked"}} id={{input-id}} name={{name}} onchange={{action "inputChanged"}} checked={{checked}} class="mdc-checkbox__native-control">
 <div class="mdc-checkbox__background">
     <svg version="1.1"
         class="mdc-checkbox__checkmark"

--- a/addon/templates/components/mdc-radio.hbs
+++ b/addon/templates/components/mdc-radio.hbs
@@ -1,4 +1,4 @@
-<input class="mdc-radio__native-control" onclick={{action "clicked"}} type="radio" id={{input-id}} name={{name}} onchange={{action "inputChanged"}}>
+<input class="mdc-radio__native-control" onclick={{action "clicked"}} type="radio" id={{input-id}} name={{name}} onchange={{action "inputChanged"}} checked={{checked}}>
 <div class="mdc-radio__background">
   <div class="mdc-radio__outer-circle"></div>
   <div class="mdc-radio__inner-circle"></div>

--- a/addon/templates/components/mdc-switch.hbs
+++ b/addon/templates/components/mdc-switch.hbs
@@ -1,4 +1,4 @@
-<input type="checkbox" onclick={{action "clicked"}} id={{input-id}} onchange={{action "inputChanged"}} class="mdc-switch__native-control" disabled={{disabled}} />
+<input type="checkbox" onclick={{action "clicked"}} id={{input-id}} onchange={{action "inputChanged"}} class="mdc-switch__native-control" disabled={{disabled}} checked={{checked}} />
 <div class="mdc-switch__background">
   <div class="mdc-switch__knob"></div>
 </div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -57,11 +57,12 @@
   </label>
   {{mdc-checkbox input-id="checkbox-for" checked=isCheckboxTwoChecked onchange=(action (mut isCheckboxTwoChecked))}}
   <label for="checkbox-for">Disassociated Label Checkbox</label>
-
   <div class="test-action-bubbling" {{action "alert" "Stop the bubbling"}}>
     {{mdc-checkbox input-id="checkbox-for" checked=isCheckboxThreeChecked onchange=(action (mut isCheckboxThreeChecked)) bubbles=false}}
     <div>Checkbox event propagation is disableable: click outside of the checkbox to test</div>
   </div>
+  {{mdc-checkbox checked=isCheckBoxFourChecked}}
+  <button {{action (toggle "isCheckBoxFourChecked" this)}}>Press to Toggle Checkbox</button>
 </section>
 
 <section class="component-doc">
@@ -95,6 +96,8 @@
     {{mdc-radio checked=isRadioFourChecked onchange=(action (mut isRadioFourChecked)) bubbles=false}}
     <div>Radio button event propagation is disableable: click outside of the checkbox to test</div>
   </div>
+  {{mdc-radio checked=isRadioFiveChecked}}
+  <button {{action (toggle "isRadioFiveChecked" this)}}>Press to Toggle Radio</button>
 </section>
 
 <section class="component-doc">
@@ -341,6 +344,7 @@
   <h2 class="mdc-typography--title">Switch</h2>
   <h3 class="mdc-typography--subheading2">Active Switch</h3>
   {{mdc-switch checked=isFirstSwitchOn onchange=(action (mut isFirstSwitchOn))}}
+  <button {{action (toggle "isFirstSwitchOn" this)}}>Press to Toggle Switch</button>
   <h3 class="mdc-typography--subheading2">Switch with Toggle Label</h3>
   <label>
     {{mdc-switch checked=isSecondSwitchOn onchange=(action (mut isSecondSwitchOn))}}
@@ -348,8 +352,6 @@
   </label>
   <h3 class="mdc-typography--subheading2">Disabled Switch</h3>
   {{mdc-switch disabled=true}}
-
-
   <h3 class="mdc-typography--subheading2">Stops Bubbling</h3>
   <div class="test-action-bubbling" {{action "alert" "Stop the bubbling"}}>
     {{mdc-switch bubbles=false}}


### PR DESCRIPTION
This implements the `checked` attribute for checkboxes, radio buttons, and switches. This allows outside input to change the state of the checkbox, radio button, or switch (e.g., a button that toggles the checked state of a checkbox).