### PR TITLE
Indicator fixes and update MDC Ripple

### DIFF
--- a/addon/components/mdc-tab-bar-scroller.js
+++ b/addon/components/mdc-tab-bar-scroller.js
@@ -146,8 +146,15 @@ export default Ember.Component.extend(MDCComponent, {
       set(this, 'tab-bar', null);
     },
     scrollActiveTabIntoView(index) {
-      // TODO: when/if Google MDC makes this method public we will need to change this line
-      get(this, 'foundation').scrollToTabAtIndex_(index);
+      // TODO: Need to submit an issue asking Google to make a scroll method that only triggers if tab is hidden, must do this until then
+      const scrollerRightBoundary = this.$('.mdc-tab-bar-scroller__scroll-frame')[0].getBoundingClientRect().right;
+      const scrollerLeftBoundary = this.$('.mdc-tab-bar-scroller__scroll-frame')[0].getBoundingClientRect().left;
+      const tabRightBoundary = get(this, 'tab-bar').tabAt(index).$()[0].getBoundingClientRect().right;
+      const tabLeftBoundary = get(this, 'tab-bar').tabAt(index).$()[0].getBoundingClientRect().left;
+      if ((tabRightBoundary > scrollerRightBoundary) || (tabLeftBoundary < scrollerLeftBoundary)) {
+        // TODO: when/if Google MDC makes this method public we will need to change this line
+        get(this, 'foundation').scrollToTabAtIndex_(index);
+      }
     }
   }
   //endregion

--- a/addon/components/mdc-tab-bar-scroller.js
+++ b/addon/components/mdc-tab-bar-scroller.js
@@ -144,6 +144,10 @@ export default Ember.Component.extend(MDCComponent, {
     },
     deregisterTabBar() {
       set(this, 'tab-bar', null);
+    },
+    scrollActiveTabIntoView(index) {
+      // TODO: when/if Google MDC makes this method public we will need to change this line
+      get(this, 'foundation').scrollToTabAtIndex_(index);
     }
   }
   //endregion

--- a/addon/components/mdc-tab-bar-scroller.js
+++ b/addon/components/mdc-tab-bar-scroller.js
@@ -152,8 +152,7 @@ export default Ember.Component.extend(MDCComponent, {
       const tabRightBoundary = get(this, 'tab-bar').tabAt(index).$()[0].getBoundingClientRect().right;
       const tabLeftBoundary = get(this, 'tab-bar').tabAt(index).$()[0].getBoundingClientRect().left;
       if ((tabRightBoundary > scrollerRightBoundary) || (tabLeftBoundary < scrollerLeftBoundary)) {
-        // TODO: when/if Google MDC makes this method public we will need to change this line
-        get(this, 'foundation').scrollToTabAtIndex_(index);
+        get(this, 'foundation').scrollToTabAtIndex(index);
       }
     }
   }

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -90,7 +90,6 @@ export default Ember.Component.extend(MDCComponent, {
     get(this, 'tabs').forEach(tab => tab.measureSelf());
     // then we need to reset the indicator styles
     if (get(this, 'foundation')) {
-      //TODO: submit a PR to Google asking to have this method made public
       get(this, 'foundation').layout();
     }
   }),

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -26,12 +26,6 @@ export default Ember.Component.extend(MDCComponent, {
    */
   dark: false,
   /**
-   * Indicates the route that is currently active. This should be passed in when using tabs as links
-   * so that the tabs are informed when the URL is changed.
-   * @type {String}
-   */
-  'current-route': null,
-  /**
    * @type {String}
    */
   'additional-indicator-classes': '',

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -26,6 +26,12 @@ export default Ember.Component.extend(MDCComponent, {
    */
   dark: false,
   /**
+   * Indicates the route that is currently active. This should be passed in when using tabs as links
+   * so that the tabs are informed when the URL is changed.
+   * @type {String}
+   */
+  'current-route': null,
+  /**
    * @type {String}
    */
   'additional-indicator-classes': '',

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -91,7 +91,7 @@ export default Ember.Component.extend(MDCComponent, {
     // then we need to reset the indicator styles
     if (get(this, 'foundation')) {
       //TODO: submit a PR to Google asking to have this method made public
-      get(this, 'foundation').layoutIndicator_();
+      get(this, 'foundation').layout();
     }
   }),
   //endregion

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -88,6 +88,11 @@ export default Ember.Component.extend(MDCComponent, {
     // its correct measurements. When the tabs swap out however, they don't know to go find their measurements. So
     // we must trigger the tab bar to inform its new tabs of their measurements.
     get(this, 'tabs').forEach(tab => tab.measureSelf());
+    // then we need to reset the indicator styles
+    if (get(this, 'foundation')) {
+      //TODO: submit a PR to Google asking to have this method made public
+      get(this, 'foundation').layoutIndicator_();
+    }
   }),
   //endregion
 
@@ -151,7 +156,9 @@ export default Ember.Component.extend(MDCComponent, {
       Ember.run.next(() => get(this, 'foundation').switchToTabAtIndex(get(this, 'tabs').indexOf(tab), true));
     },
     scrollTabIntoView(tab) {
-      Ember.run.next(() => get(this, 'scroll-active-tab-into-view')(get(this, 'tabs').indexOf(tab)));
+      if (get(this, 'scroll-active-tab-into-view')) {
+        Ember.run.next(() => get(this, 'scroll-active-tab-into-view')(get(this, 'tabs').indexOf(tab)));
+      }
     }
   }
   //endregion

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -153,10 +153,12 @@ export default Ember.Component.extend(MDCComponent, {
       get(this, 'tabs').removeObject(tab);
     },
     switchToTab(tab) {
-      Ember.run.next(() => get(this, 'foundation').switchToTabAtIndex(get(this, 'tabs').indexOf(tab), true));
+      if (get(this, 'tabs.length')) {
+        Ember.run.next(() => get(this, 'foundation').switchToTabAtIndex(get(this, 'tabs').indexOf(tab), true));
+      }
     },
     scrollTabIntoView(tab) {
-      if (get(this, 'scroll-active-tab-into-view')) {
+      if (get(this, 'scroll-active-tab-into-view') && get(this, 'tabs.length')) {
         Ember.run.next(() => get(this, 'scroll-active-tab-into-view')(get(this, 'tabs').indexOf(tab)));
       }
     }

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -153,13 +153,11 @@ export default Ember.Component.extend(MDCComponent, {
       get(this, 'tabs').removeObject(tab);
     },
     switchToTab(tab) {
-      if (get(this, 'tabs.length')) {
-        Ember.run.next(() => get(this, 'foundation').switchToTabAtIndex(get(this, 'tabs').indexOf(tab), true));
-      }
+      Ember.run.next(() => get(this, 'tabs.length') ? get(this, 'foundation').switchToTabAtIndex(get(this, 'tabs').indexOf(tab), true) : null);
     },
     scrollTabIntoView(tab) {
-      if (get(this, 'scroll-active-tab-into-view') && get(this, 'tabs.length')) {
-        Ember.run.next(() => get(this, 'scroll-active-tab-into-view')(get(this, 'tabs').indexOf(tab)));
+      if (get(this, 'scroll-active-tab-into-view')) {
+        Ember.run.next(() => get(this, 'tabs.length') ? get(this, 'scroll-active-tab-into-view')(get(this, 'tabs').indexOf(tab)) : null);
       }
     }
   }

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -6,7 +6,7 @@ import getElementProperty from '../utils/get-element-property';
 import getComponentProperty from '../utils/get-component-property';
 import styleComputed from '../utils/style-computed';
 
-const { computed, get, set } = Ember;
+const { computed, observer, get, set } = Ember;
 const { strings } = MDCTabBarFoundation;
 
 export default Ember.Component.extend(MDCComponent, {
@@ -80,6 +80,15 @@ export default Ember.Component.extend(MDCComponent, {
   indicatorStyle: styleComputed('mdcIndicatorStyles'),
   isIconsOnly: computed.equal('icons', 'only'),
   isIconsWithText: computed.equal('icons', 'with-text'),
+  //endregion
+
+  //region Observers
+  tabsChanged: observer('tabs.@each.foundation', function() {
+    // When a tab is first rendered, its computed measurements are zero. It relies on the tab bar to tell it to find
+    // its correct measurements. When the tabs swap out however, they don't know to go find their measurements. So
+    // we must trigger the tab bar to inform its new tabs of their measurements.
+    get(this, 'tabs').forEach(tab => tab.measureSelf());
+  }),
   //endregion
 
   //region Method

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -26,12 +26,6 @@ export default Ember.Component.extend(MDCComponent, {
    */
   dark: false,
   /**
-   * Indicates the route that is currently active. This should be passed in when using tabs as links
-   * so that the tabs are informed when the URL is changed.
-   * @type {String}
-   */
-  'current-route': null,
-  /**
    * @type {String}
    */
   'additional-indicator-classes': '',
@@ -125,7 +119,9 @@ export default Ember.Component.extend(MDCComponent, {
   },
   setTabActiveAtIndex(index, isActive) {
     if (get(this, 'links')) {
-      this.tabAt(index)._invoke({ stopPropagation() {}, preventDefault() {} }); // TODO: Probably shouldn't be calling private APIs or stubbing events
+      if (this.tabAt(index) && isActive) {
+        this.tabAt(index)._invoke({ stopPropagation() {}, preventDefault() {} }); // TODO: Probably shouldn't be calling private APIs or stubbing events
+      }
     }
     else {
       get(this.tabAt(index), 'become-active')(isActive);

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -121,6 +121,9 @@ export default Ember.Component.extend(MDCComponent, {
     if (get(this, 'links')) {
       if (this.tabAt(index) && isActive) {
         this.tabAt(index)._invoke({ stopPropagation() {}, preventDefault() {} }); // TODO: Probably shouldn't be calling private APIs or stubbing events
+        if (get(this, 'scroll-active-tab-into-view')) {
+          get(this, 'scroll-active-tab-into-view')(index);
+        }
       }
     }
     else {
@@ -146,6 +149,9 @@ export default Ember.Component.extend(MDCComponent, {
     },
     switchToTab(tab) {
       Ember.run.next(() => get(this, 'foundation').switchToTabAtIndex(get(this, 'tabs').indexOf(tab), true));
+    },
+    scrollTabIntoView(tab) {
+      Ember.run.next(() => get(this, 'scroll-active-tab-into-view')(get(this, 'tabs').indexOf(tab)));
     }
   }
   //endregion

--- a/addon/components/mdc-tab-bar/tab-link.js
+++ b/addon/components/mdc-tab-bar/tab-link.js
@@ -6,6 +6,12 @@ const { get, observer } = Ember;
 export default Ember.LinkComponent.extend(MDCTabComponent, {
   //region Ember Hooks
   activeClass: 'mdc-tab--active',
+  didInsertElement() {
+    this._super(...arguments);
+    if (get(this, 'active')) {
+      get(this, 'scroll-into-view')(this);
+    }
+  },
   //endregion
 
   //region Observers

--- a/addon/components/mdc-tab-bar/tab-link.js
+++ b/addon/components/mdc-tab-bar/tab-link.js
@@ -9,10 +9,10 @@ export default Ember.LinkComponent.extend(MDCTabComponent, {
   //endregion
 
   //region Observers
-  activeStateChanged: observer('active', function() {
-    if (get(this, 'active')) {
-      get(this, 'switch-to-tab')(this);
-    }
-  }),
+  // activeStateChanged: observer('active', function() {
+  //   if (get(this, 'active')) {
+  //     get(this, 'switch-to-tab')(this);
+  //   }
+  // }),
   //endregion
 });

--- a/addon/components/mdc-tab-bar/tab-link.js
+++ b/addon/components/mdc-tab-bar/tab-link.js
@@ -1,8 +1,18 @@
 import Ember from 'ember';
 import MDCTabComponent from '../../mixins/mdc-tab-component';
 
+const { get, observer } = Ember;
+
 export default Ember.LinkComponent.extend(MDCTabComponent, {
   //region Ember Hooks
-  activeClass: 'mdc-tab--active'
+  activeClass: 'mdc-tab--active',
+  //endregion
+
+  //region Observers
+  activeStateChanged: observer('active', function() {
+    if (get(this, 'active')) {
+      get(this, 'switch-to-tab')(this);
+    }
+  }),
   //endregion
 });

--- a/addon/components/mdc-tab-bar/tab-link.js
+++ b/addon/components/mdc-tab-bar/tab-link.js
@@ -1,18 +1,8 @@
 import Ember from 'ember';
 import MDCTabComponent from '../../mixins/mdc-tab-component';
 
-const { get, observer } = Ember;
-
 export default Ember.LinkComponent.extend(MDCTabComponent, {
   //region Ember Hooks
-  activeClass: 'mdc-tab--active',
-  //endregion
-
-  //region Observers
-  // activeStateChanged: observer('active', function() {
-  //   if (get(this, 'active')) {
-  //     get(this, 'switch-to-tab')(this);
-  //   }
-  // }),
+  activeClass: 'mdc-tab--active'
   //endregion
 });

--- a/addon/mixins/mdc-component.js
+++ b/addon/mixins/mdc-component.js
@@ -139,7 +139,7 @@ export const MDCComponent = Ember.Mixin.create({
   },
 
   setStyleFor(key, property, value) {
-    Ember.run(() => {
+    Ember.run.next(() => {
       if (get(this, 'isDestroyed')) { return; }
 
       set(this, `${key}.${property}`, value);

--- a/addon/mixins/mdc-tab-component.js
+++ b/addon/mixins/mdc-tab-component.js
@@ -6,16 +6,6 @@ import layout from '../templates/components/mdc-tab-bar/tab';
 const { get } = Ember;
 
 export default Ember.Mixin.create(MDCComponent, {
-  //region Attributes
-  /**
-   * Indicates the route that is currently active. This is passed from inside the mdc-tab-bar handlebars.
-   * When the route changes, this attribute gets triggered and the indicator adjusts accordingly.
-   * @private
-   * @type {String}
-   */
-  'current-route': null,
-  //endregion
-
   //region Ember Hooks
   layout,
   classNames: ['mdc-tab'],

--- a/addon/mixins/mdc-tab-component.js
+++ b/addon/mixins/mdc-tab-component.js
@@ -6,6 +6,16 @@ import layout from '../templates/components/mdc-tab-bar/tab';
 const { get } = Ember;
 
 export default Ember.Mixin.create(MDCComponent, {
+  //region Attributes
+  /**
+   * Indicates the route that is currently active. This is passed from inside the mdc-tab-bar handlebars.
+   * When the route changes, this attribute gets triggered and the indicator adjusts accordingly.
+   * @private
+   * @type {String}
+   */
+  'current-route': null,
+  //endregion
+
   //region Ember Hooks
   layout,
   classNames: ['mdc-tab'],

--- a/addon/templates/components/mdc-tab-bar-scroller.hbs
+++ b/addon/templates/components/mdc-tab-bar-scroller.hbs
@@ -10,6 +10,7 @@
           class="mdc-tab-bar-scroller__scroll-frame__tabs"
           register-tab-bar=(action "registerTabBar")
           deregister-tab-bar=(action "deregisterTabBar")
+          scroll-active-tab-into-view=(action "scrollActiveTabIntoView")
           style=scrollFrameStyles
     )
   )}}

--- a/addon/templates/components/mdc-tab-bar.hbs
+++ b/addon/templates/components/mdc-tab-bar.hbs
@@ -2,7 +2,6 @@
   tab=(component
     (if links "mdc-tab-bar/tab-link" "mdc-tab-bar/tab")
     has-icon-and-text=isIconsWithText
-    current-route=current-route
     tab-selected=(action "tabSelected")
     register-tab=(action "registerTab")
     deregister-tab=(action "deregisterTab")

--- a/addon/templates/components/mdc-tab-bar.hbs
+++ b/addon/templates/components/mdc-tab-bar.hbs
@@ -6,6 +6,7 @@
     register-tab=(action "registerTab")
     deregister-tab=(action "deregisterTab")
     switch-to-tab=(action "switchToTab")
+    scroll-into-view=(action "scrollTabIntoView")
   )
 )}}
 {{mdc-tab-bar/indicator class=additional-indicator-classes style=indicatorStyle}}

--- a/addon/templates/components/mdc-tab-bar.hbs
+++ b/addon/templates/components/mdc-tab-bar.hbs
@@ -2,6 +2,7 @@
   tab=(component
     (if links "mdc-tab-bar/tab-link" "mdc-tab-bar/tab")
     has-icon-and-text=isIconsWithText
+    current-route=current-route
     tab-selected=(action "tabSelected")
     register-tab=(action "registerTab")
     deregister-tab=(action "deregisterTab")

--- a/blueprints/ember-material-components-web/index.js
+++ b/blueprints/ember-material-components-web/index.js
@@ -19,7 +19,7 @@ module.exports = {
       { name: '@material/textfield', target: '0.3.6' },
       { name: '@material/menu', target: '0.4.5' },
       { name: '@material/toolbar', target: '0.4.7'},
-      { name: '@material/tabs', target: '0.2.8'},
+      { name: '@material/tabs', target: '0.3.0'},
       { name: '@material/ripple', target: '0.8.6'},
       { name: '@material/linear-progress', target: '0.1.8'},
       { name: '@material/switch', target: '0.1.12'}

--- a/blueprints/ember-material-components-web/index.js
+++ b/blueprints/ember-material-components-web/index.js
@@ -20,7 +20,7 @@ module.exports = {
       { name: '@material/menu', target: '0.4.5' },
       { name: '@material/toolbar', target: '0.4.7'},
       { name: '@material/tabs', target: '0.2.8'},
-      { name: '@material/ripple', target: '0.8.5'},
+      { name: '@material/ripple', target: '0.8.6'},
       { name: '@material/linear-progress', target: '0.1.8'},
       { name: '@material/switch', target: '0.1.12'}
     ]);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@material/list": "0.2.17",
     "@material/menu": "0.4.5",
     "@material/radio": "0.2.12",
-    "@material/ripple": "0.8.5",
+    "@material/ripple": "0.8.6",
     "@material/switch": "0.1.12",
     "@material/tabs": "0.2.8",
     "@material/textfield": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@material/radio": "0.2.12",
     "@material/ripple": "0.8.6",
     "@material/switch": "0.1.12",
-    "@material/tabs": "0.2.8",
+    "@material/tabs": "0.3.0",
     "@material/textfield": "0.3.6",
     "@material/theme": "0.2.0",
     "@material/toolbar": "0.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,10 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.3.0.tgz#57b13c75e705eba9686ec5e9fd03a361738ce76a"
 
+"@material/animation@^0.4.0":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.4.1.tgz#bf8b50aedad4cffce8a5b428fdca8f1abbaf176e"
+
 "@material/base@0.2.5", "@material/base@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@material/base/-/base-0.2.5.tgz#d721a8add68bbfa8ed6759c6bbd9107cd272a2b0"
@@ -136,19 +140,19 @@
     "@material/selection-control" "^0.1.0"
     "@material/theme" "^0.2.0"
 
-"@material/ripple@0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.8.5.tgz#8e3d6f3161894e2dbc2e11952cb4b6add442a7dd"
-  dependencies:
-    "@material/base" "^0.2.5"
-    "@material/theme" "^0.2.0"
-
-"@material/ripple@^0.8.5", "@material/ripple@^0.8.6":
+"@material/ripple@0.8.6", "@material/ripple@^0.8.5", "@material/ripple@^0.8.6":
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.8.6.tgz#039ec22937f78bcfefa330d3533c77852466d8d8"
   dependencies:
     "@material/base" "^0.2.5"
     "@material/theme" "^0.3.0"
+
+"@material/ripple@^0.8.7":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.8.8.tgz#22b89ed9e63883f17fa4f00d12370e32e0c459b7"
+  dependencies:
+    "@material/base" "^0.2.6"
+    "@material/theme" "^0.4.0"
 
 "@material/rtl@^0.1.7":
   version "0.1.7"
@@ -172,15 +176,15 @@
     "@material/elevation" "^0.1.11"
     "@material/theme" "^0.2.0"
 
-"@material/tabs@0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@material/tabs/-/tabs-0.2.8.tgz#633fb7b7190b8e33f775fd9f563e2a35f5687846"
+"@material/tabs@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@material/tabs/-/tabs-0.3.0.tgz#a5f5df2b79d1a825bfbf90a839b6381c2d943a59"
   dependencies:
-    "@material/animation" "^0.3.1"
+    "@material/animation" "^0.4.0"
     "@material/base" "^0.2.5"
-    "@material/ripple" "^0.8.5"
-    "@material/rtl" "^0.1.7"
-    "@material/theme" "^0.2.0"
+    "@material/ripple" "^0.8.7"
+    "@material/rtl" "^0.1.8"
+    "@material/theme" "^0.3.1"
     "@material/typography" "^0.3.0"
 
 "@material/textfield@0.3.6":
@@ -205,6 +209,10 @@
 "@material/theme@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.3.0.tgz#d0e7622c77aebbd9416e6561c31ff4a8338d1f06"
+
+"@material/theme@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.3.1.tgz#6ff261ff72b3493a5cc6e746da3b472d072aa5a9"
 
 "@material/theme@^0.4.0":
   version "0.4.0"


### PR DESCRIPTION
Fixes various bugs with the MDC Tab Bar and its navigation behavior:

- **Tabs as links**: Indicator will now respond to changes in the URL or query params not triggered by clicking the tabs directly.
- When the array of tabs changes to a different set of tabs without un-rendering the parent tab bar, the indicator is updated accordingly.
- Tab bar scroller will now scroll hidden active tabs into view.

Additionally, MDC Ripple has been upgraded to the latest version to fix styling issues in Edge.