### PR TITLE
:bug: Hide the placeholder until the input has focus

### DIFF
--- a/addon/components/mdc-textfield.js
+++ b/addon/components/mdc-textfield.js
@@ -165,6 +165,12 @@ export default Ember.Component.extend(MDCComponent, {
   //endregion
 
   //region Computed Properties
+  isFocused: computed('mdcClassNames', function (){
+    const mdcClassNames = get(this, 'mdcClassNames').split(' ');
+    const focusedClassName = get(this, 'CLASS_NAMES.FOCUSED');
+    return mdcClassNames.includes(focusedClassName);
+  }),
+
   /**
    * @type {String}
    */

--- a/addon/templates/components/mdc-textfield.hbs
+++ b/addon/templates/components/mdc-textfield.hbs
@@ -19,7 +19,7 @@
       oninput=(action "handleInput")
       onkeydown=(action "handle" "keydown")
       required=required
-      placeholder=placeholder
+      placeholder=(if isFocused placeholder)
       disabled=disabled
       readonly=readonly
       type=type

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -158,7 +158,6 @@
     type="email"
     helptext="This will not be sent to any server"
   }}
-  TODO: Bug with placeholder + label.
 
   {{mdc-textfield
     label="Recipient Email"

--- a/tests/integration/components/mdc-textfield-test.js
+++ b/tests/integration/components/mdc-textfield-test.js
@@ -14,3 +14,14 @@ test('it renders', function(assert) {
 
   assert.equal(this.$().text().trim(), '');
 });
+
+test('it detects if it is focused based upon classnames', function(assert) {
+  const placeholderText='Hi I am the placeholder';
+  this.set('placeholderText', placeholderText);
+
+  this.render(hbs`{{mdc-textfield placeholder=placeholderText label='This is a Label'}}`);
+
+  assert.notOk(this.$('input').attr('placeholder'), 'Without focus the placeholder is NOT displayed');
+  this.$('input').trigger('focusin');
+  assert.equal(this.$('input').attr('placeholder'), placeholderText, 'With focus the placeholder IS displayed');
+});


### PR DESCRIPTION
**Did you confirm this fix/feature is something that is needed?** Yes, Issue #2 

**Did you write automated tests?** Yes

**Did you add documentation for the changes you made?** Updated the `dummy/app/templates/application.hbs` to remove the _TODO_

**In lieu of a style guide, did you match your code style to the rest of the project?** Yes