### PR TITLE
Add `disable-focus` Attribute to Prevent Focus on Menu Open

### DIFF
--- a/addon/components/mdc-linear-progress.js
+++ b/addon/components/mdc-linear-progress.js
@@ -5,7 +5,7 @@ import { MDCComponent } from '../mixins/mdc-component';
 import getElementProperty from '../utils/get-element-property';
 import styleComputed from '../utils/style-computed';
 
-const { get, set } = Ember;
+const { get, run, set } = Ember;
 
 const { cssClasses, strings } = MDCLinearProgressFoundation;
 
@@ -90,7 +90,7 @@ export default Ember.Component.extend(MDCComponent, {
         else if (el.classList.contains(strings.BUFFER_SELECTOR.slice(1))) {
           elementStyles = 'mdcBufferStyles';
         }
-        this.setStyleFor(elementStyles, property, value);
+        run(() => this.setStyleFor(elementStyles, property, value));
       }
     });
   },

--- a/addon/components/mdc-menu.js
+++ b/addon/components/mdc-menu.js
@@ -4,7 +4,7 @@ import { MDCComponent } from '../mixins/mdc-component';
 import styleComputed from '../utils/style-computed';
 import { MDCSimpleMenuFoundation, util } from '@material/menu';
 
-const { get, set } = Ember;
+const { get, run, set } = Ember;
 const { strings } = MDCSimpleMenuFoundation;
 const TRANSFORM_PROPERTY = util.getTransformPropertyName(window);
 
@@ -97,8 +97,8 @@ export default Ember.Component.extend(MDCComponent, {
   },
   createFoundation() {
     return new MDCSimpleMenuFoundation({
-      addClass: className => get(this, 'mdcClasses').addObject(className),
-      removeClass: className => get(this, 'mdcClasses').removeObject(className),
+      addClass: className => run(() => get(this, 'mdcClasses').addObject(className)),
+      removeClass: className => run(() => get(this, 'mdcClasses').removeObject(className)),
       hasClass: className => get(this, 'element.classList').contains(className),
       hasNecessaryDom: () => !!get(this , 'element') && !!this.$(strings.ITEMS_SELECTOR).length,
       getInnerDimensions: () => {
@@ -108,8 +108,8 @@ export default Ember.Component.extend(MDCComponent, {
       hasAnchor: () => get(this, 'anchor'),
       getAnchorDimensions: () => get(this, 'anchor').getAnchorDimensions(),
       getWindowDimensions: () => ({ width: window.innerWidth, height: window.innerHeight }),
-      setScale: (x, y) => this.setStyleFor('mdcStyles', TRANSFORM_PROPERTY, `scale(${x}, ${y}`),
-      setInnerScale: (x, y)  => this.setStyleFor('itemStyles', TRANSFORM_PROPERTY, `scale(${x}, ${y}`),
+      setScale: (x, y) => run(() => this.setStyleFor('mdcStyles', TRANSFORM_PROPERTY, `scale(${x}, ${y}`)),
+      setInnerScale: (x, y)  => run(() => this.setStyleFor('itemStyles', TRANSFORM_PROPERTY, `scale(${x}, ${y}`)),
       getNumberOfItems: () => get(this, 'items.length'),
       registerInteractionHandler: (type, handler) => this.registerMdcInteractionHandler(type, handler),
       deregisterInteractionHandler: (type, handler) => this.deregisterMdcInteractionHandler(type, handler),
@@ -123,16 +123,18 @@ export default Ember.Component.extend(MDCComponent, {
       saveFocus: () => set(this, 'previousFocus', document.activeElement),
       restoreFocus: () => get(this, 'previousFocus') && get(this, 'previousFocus').focus(),
       isFocused: () => document.activeElement === get(this, 'element'),
-      focus: ()  => get(this, 'element').focus(),
+      focus: ()  => run(() => get(this, 'element').focus()),
       getFocusedItemIndex: () => get(this, 'items').mapBy('element').indexOf(document.activeElement),
       focusItemAtIndex: index => get(this.itemAt(index), 'element').focus(),
       isRtl: ()  => window.getComputedStyle(get(this, 'element')).getPropertyValue('direction') === 'rtl',
-      setTransformOrigin: value => this.setStyleFor('mdcStyles', `${TRANSFORM_PROPERTY}-origin`, value),
+      setTransformOrigin: value => run(() => this.setStyleFor('mdcStyles', `${TRANSFORM_PROPERTY}-origin`, value)),
       setPosition: ({ top, right, bottom, left }) => {
-        this.setStyleFor('mdcStyles', 'top', top || null);
-        this.setStyleFor('mdcStyles', 'right', right || null);
-        this.setStyleFor('mdcStyles', 'bottom', bottom || null);
-        this.setStyleFor('mdcStyles', 'left', left || null);
+        run(() => {
+          this.setStyleFor('mdcStyles', 'top', top || null);
+          this.setStyleFor('mdcStyles', 'right', right || null);
+          this.setStyleFor('mdcStyles', 'bottom', bottom || null);
+          this.setStyleFor('mdcStyles', 'left', left || null);
+        });
       },
       getAccurateTime: () => window.performance.now()
     });

--- a/addon/components/mdc-menu.js
+++ b/addon/components/mdc-menu.js
@@ -47,7 +47,7 @@ export default Ember.Component.extend(MDCComponent, {
   layout,
   classNames: ['mdc-simple-menu'],
   classNameBindings: ['mdcClassNames', 'open:mdc-simple-menu--open'],
-  attributeBindings: ['style'],
+  attributeBindings: ['style', 'tabindex'],
   //endregion
 
   //region Properties

--- a/addon/components/mdc-menu.js
+++ b/addon/components/mdc-menu.js
@@ -28,6 +28,11 @@ export default Ember.Component.extend(MDCComponent, {
    * @type {?Function}
    */
   cancel: x => x,
+  /**
+   * Enabling this is generally a bad idea for accessibility, so think hard about using this attribute.
+   * @type {Boolean}
+   */
+  'disable-focus': false,
   //endregion
 
   //region Ember Hooks
@@ -123,9 +128,9 @@ export default Ember.Component.extend(MDCComponent, {
       saveFocus: () => set(this, 'previousFocus', document.activeElement),
       restoreFocus: () => get(this, 'previousFocus') && get(this, 'previousFocus').focus(),
       isFocused: () => document.activeElement === get(this, 'element'),
-      focus: ()  => run(() => get(this, 'element').focus()),
+      focus: ()  => run(() => !get(this, 'disable-focus') && get(this, 'element').focus()),
       getFocusedItemIndex: () => get(this, 'items').mapBy('element').indexOf(document.activeElement),
-      focusItemAtIndex: index => get(this.itemAt(index), 'element').focus(),
+      focusItemAtIndex: index => !get(this, 'disable-focus') && get(this.itemAt(index), 'element').focus(),
       isRtl: ()  => window.getComputedStyle(get(this, 'element')).getPropertyValue('direction') === 'rtl',
       setTransformOrigin: value => run(() => this.setStyleFor('mdcStyles', `${TRANSFORM_PROPERTY}-origin`, value)),
       setPosition: ({ top, right, bottom, left }) => {

--- a/addon/components/mdc-radio.js
+++ b/addon/components/mdc-radio.js
@@ -5,7 +5,7 @@ import { MDCComponent } from '../mixins/mdc-component';
 import { MDCRadioFoundation } from '@material/radio';
 import SupportsBubblesFalse from '../mixins/supports-bubbles-false';
 
-const { get } = Ember;
+const { get, run } = Ember;
 
 export default Ember.Component.extend(MDCComponent, SupportsBubblesFalse, {
   //region Attributes
@@ -90,8 +90,8 @@ export default Ember.Component.extend(MDCComponent, SupportsBubblesFalse, {
    */
   createFoundation() {
     return new MDCRadioFoundation({
-      addClass: className => get(this, 'mdcClasses').addObject(className),
-      removeClass: className => get(this, 'mdcClasses').removeObject(className),
+      addClass: className => run(() => get(this, 'mdcClasses').addObject(className)),
+      removeClass: className => run(() => get(this, 'mdcClasses').removeObject(className)),
       getNativeControl: () => this.$('input').get(0),
     });
   },

--- a/addon/components/mdc-tab-bar-scroller.js
+++ b/addon/components/mdc-tab-bar-scroller.js
@@ -7,7 +7,7 @@ import getElementProperty from '../utils/get-element-property';
 import getComponentProperty from '../utils/get-component-property';
 import styleComputed from '../utils/style-computed';
 
-const { get, computed, set, run } = Ember;
+const { computed, get, run, set } = Ember;
 const { cssClasses, strings } = MDCTabBarScrollerFoundation;
 
 export default Ember.Component.extend(MDCComponent, {
@@ -113,7 +113,7 @@ export default Ember.Component.extend(MDCComponent, {
       setScrollLeftForScrollFrame: (scrollLeftAmount) =>  get(this, 'scrollFrameElement').scrollLeft = scrollLeftAmount,
       getOffsetWidthForTabBar: () => get(this, 'tabBarElement').offsetWidth,
       setTransformStyleForTabBar: (value) => {
-        this.setStyleFor('mdcScrollFrameStyles', getCorrectPropertyName(window, 'transform'), value);
+        run(() => this.setStyleFor('mdcScrollFrameStyles', getCorrectPropertyName(window, 'transform'), value));
       },
       getOffsetLeftForEventTarget: (target) => target.offsetLeft,
       getOffsetWidthForEventTarget: (target) => target.offsetWidth

--- a/addon/components/mdc-tab-bar.js
+++ b/addon/components/mdc-tab-bar.js
@@ -6,7 +6,7 @@ import getElementProperty from '../utils/get-element-property';
 import getComponentProperty from '../utils/get-component-property';
 import styleComputed from '../utils/style-computed';
 
-const { computed, observer, get, set } = Ember;
+const { computed, get, observer, run, set } = Ember;
 const { strings } = MDCTabBarFoundation;
 
 export default Ember.Component.extend(MDCComponent, {
@@ -105,7 +105,7 @@ export default Ember.Component.extend(MDCComponent, {
       registerResizeHandler: (handler) => window.addEventListener('resize', handler),
       deregisterResizeHandler: (handler) => window.removeEventListener('resize', handler),
       getOffsetWidth: () => getElementProperty(this, 'offsetWidth', 0),
-      setStyleForIndicator: (propertyName, value) => this.setStyleFor('mdcIndicatorStyles', propertyName, value),
+      setStyleForIndicator: (propertyName, value) => run(() => this.setStyleFor('mdcIndicatorStyles', propertyName, value)),
       getOffsetWidthForIndicator: () => getElementProperty(this, 'querySelector', () => ({ offsetWidth: 0 }))(strings.INDICATOR_SELECTOR).offsetWidth,
       notifyChange: (evtData) => get(this, 'onchange')(evtData), // TODO
       getNumberOfTabs: () => get(this, 'tabs.length'),

--- a/addon/components/mdc-toolbar.js
+++ b/addon/components/mdc-toolbar.js
@@ -5,7 +5,7 @@ import { MDCComponent } from '../mixins/mdc-component';
 import getElementProperty from '../utils/get-element-property';
 import styleComputed from '../utils/style-computed';
 
-const { get, set } = Ember;
+const { get, set, run } = Ember;
 
 const { cssClasses, strings } = MDCToolbarFoundation;
 
@@ -78,8 +78,8 @@ export default Ember.Component.extend(MDCComponent, {
   createFoundation() {
     return new MDCToolbarFoundation({
       hasClass: (className) => get(this, 'element').classList.contains(className),
-      addClass: (className) => Ember.run(() => get(this, 'mdcClasses').addObject(className)),
-      removeClass: (className) => Ember.run(() => get(this, 'mdcClasses').removeObject(className)),
+      addClass: (className) => run(() => get(this, 'mdcClasses').addObject(className)),
+      removeClass: (className) => run(() => get(this, 'mdcClasses').removeObject(className)),
       registerScrollHandler: (handler) => window.addEventListener('scroll', handler, util.applyPassive()),
       deregisterScrollHandler: (handler) => window.removeEventListener('scroll', handler, util.applyPassive()),
       registerResizeHandler: (handler) => window.addEventListener('resize', handler),
@@ -88,10 +88,10 @@ export default Ember.Component.extend(MDCComponent, {
       getViewportScrollY: () => window.pageYOffset,
       getOffsetHeight: () => getElementProperty(this, 'offsetHeight', 0),
       getFirstRowElementOffsetHeight: () => getElementProperty(this, 'querySelector', () => ({ offsetHeight: 0 }))(strings.FIRST_ROW_SELECTOR).offsetHeight,
-      notifyChange: (evtData) => Ember.run(() => get(this, 'onchange')(evtData)),
-      setStyle: (property, value) => this.setStyleFor('mdcStyles', property, value),
-      setStyleForTitleElement: (property, value) => this.setStyleFor('mdcTitleStyles', property, value),
-      setStyleForFlexibleRowElement: (property, value) => this.setStyleFor('mdcFirstRowStyles', property, value),
+      notifyChange: (evtData) => run(() => get(this, 'onchange')(evtData)),
+      setStyle: (property, value) => run(() => this.setStyleFor('mdcStyles', property, value)),
+      setStyleForTitleElement: (property, value) => run(() => this.setStyleFor('mdcTitleStyles', property, value)),
+      setStyleForFlexibleRowElement: (property, value) => run(() => this.setStyleFor('mdcFirstRowStyles', property, value)),
       setStyleForFixedAdjustElement: () => null, // no-op
     });
   },

--- a/addon/utils/mdc-ripple-adapter.js
+++ b/addon/utils/mdc-ripple-adapter.js
@@ -21,7 +21,7 @@ export const createRippleAdapter = (component, overrides) => Object.assign({
   deregisterInteractionHandler: (evtType, handler) => component.deregisterMdcInteractionHandler(evtType, handler),
   registerResizeHandler: handler => window.addEventListener('resize', handler),
   deregisterResizeHandler: handler => window.removeEventListener('resize', handler),
-  updateCssVariable: (varName, value) => component.setStyleFor('mdcStyles', varName, value),
+  updateCssVariable: (varName, value) => run(() => component.setStyleFor('mdcStyles', varName, value)),
   computeBoundingRect: () => getElementProperty(component, 'getBoundingClientRect', () => ({ top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0 }))(),
   getWindowPageOffset: () => ({ x: window.pageXOffset, y: window.pageYOffset })
 }, overrides);


### PR DESCRIPTION
# Developer Notes

- Adds ability to disable the focus on the menu when it's opened (not ideal for accessibility reasons!) via the `disable-focus` attribute. Defaults to`false`. 

- `tabindex` is now bound so it can be set in `{{mdc-menu}}`