### PR TITLE
AutoDeploy docs to GitHub Pages on merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,14 @@ script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
+
+before_deploy:
+  - node_modules/.bin/ember build production
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: ./dist
+  on:
+    branch: master


### PR DESCRIPTION
Noticed that the demo page is outdated, probably because its manually deployed via the gh-pages branch. I've had success auto-deploying to github pages via travis deployments on merges to master on other ember addon repos. This PR does the same for this repo.

Before merging this PR set [a personal GitHub token](https://github.com/settings/tokens) to the environment variable `GITHUB_TOKEN` on the [travis settings page](https://travis-ci.org/secondstreet/ember-material-components-web/settings).