### PR TITLE
Additional check before the foundation is initiated on a component

### DIFF
--- a/addon/mixins/mdc-component.js
+++ b/addon/mixins/mdc-component.js
@@ -36,7 +36,7 @@ export const MDCComponent = Mixin.create({
     // parent's didInsertElement.
     scheduleOnce('afterRender', this, () => {
       this._attachMdcInteractionHandlers();
-      if (get(this, 'createFoundation')) {
+      if (get(this, 'createFoundation') && !get(this, 'isDestroyed')) {
         const foundation = this.createFoundation();
         set(this, 'foundation', foundation);
         foundation.init();


### PR DESCRIPTION
- Bug fix: the consuming application was throwing an error when it was trying to set the foundation on a destroyed component. This PR adds an additional check for `isDestroyed` before setting the foundation.