### PR TITLE
:bug: destroyed mdc-menus have no items to notify about

### DIFF
--- a/addon/components/mdc-menu.js
+++ b/addon/components/mdc-menu.js
@@ -128,13 +128,13 @@ export default Component.extend(MDCComponent, {
       deregisterInteractionHandler: (type, handler) => this.deregisterMdcInteractionHandler(type, handler),
       registerBodyClickHandler: handler => document.body.addEventListener('click', handler),
       deregisterBodyClickHandler: handler => document.body.removeEventListener('click', handler),
-      getYParamsForItemAtIndex: index => this.itemAt(index).getYParams(),
-      setTransitionDelayForItemAtIndex: (index, value) => this.itemAt(index).setTransitionDelay(value),
+      getYParamsForItemAtIndex: index => !get(this, 'isDestroyed') && this.itemAt(index).getYParams(),
+      setTransitionDelayForItemAtIndex: (index, value) => !get(this, 'isDestroyed') && this.itemAt(index).setTransitionDelay(value),
       getIndexForEventTarget: target =>
         get(this, 'items')
           .mapBy('element')
           .indexOf(target),
-      notifySelected: ({ index }) => this.itemAt(index).notifySelected(index),
+      notifySelected: ({ index }) => !get(this, 'isDestroyed') && this.itemAt(index).notifySelected(index),
       notifyCancel: () => get(this, 'cancel')(false), // False is provided as a convenience for the {{mut}} helper
       saveFocus: () => set(this, 'previousFocus', document.activeElement),
       restoreFocus: () => get(this, 'previousFocus') && get(this, 'previousFocus').focus(),
@@ -144,7 +144,7 @@ export default Component.extend(MDCComponent, {
         get(this, 'items')
           .mapBy('element')
           .indexOf(document.activeElement),
-      focusItemAtIndex: index => !get(this, 'disable-focus') && get(this.itemAt(index), 'element').focus(),
+      focusItemAtIndex: index => !get(this, 'isDestroyed') && !get(this, 'disable-focus') && get(this.itemAt(index), 'element').focus(),
       isRtl: () => window.getComputedStyle(get(this, 'element')).getPropertyValue('direction') === 'rtl',
       setTransformOrigin: value => run(() => this.setStyleFor('mdcStyles', `${TRANSFORM_PROPERTY}-origin`, value)),
       setPosition: ({ top, right, bottom, left }) => {

--- a/addon/components/mdc-menu.js
+++ b/addon/components/mdc-menu.js
@@ -129,7 +129,8 @@ export default Component.extend(MDCComponent, {
       registerBodyClickHandler: handler => document.body.addEventListener('click', handler),
       deregisterBodyClickHandler: handler => document.body.removeEventListener('click', handler),
       getYParamsForItemAtIndex: index => !get(this, 'isDestroyed') && this.itemAt(index).getYParams(),
-      setTransitionDelayForItemAtIndex: (index, value) => !get(this, 'isDestroyed') && this.itemAt(index).setTransitionDelay(value),
+      setTransitionDelayForItemAtIndex: (index, value) =>
+        !get(this, 'isDestroyed') && this.itemAt(index).setTransitionDelay(value),
       getIndexForEventTarget: target =>
         get(this, 'items')
           .mapBy('element')
@@ -144,7 +145,8 @@ export default Component.extend(MDCComponent, {
         get(this, 'items')
           .mapBy('element')
           .indexOf(document.activeElement),
-      focusItemAtIndex: index => !get(this, 'isDestroyed') && !get(this, 'disable-focus') && get(this.itemAt(index), 'element').focus(),
+      focusItemAtIndex: index =>
+        !get(this, 'isDestroyed') && !get(this, 'disable-focus') && get(this.itemAt(index), 'element').focus(),
       isRtl: () => window.getComputedStyle(get(this, 'element')).getPropertyValue('direction') === 'rtl',
       setTransformOrigin: value => run(() => this.setStyleFor('mdcStyles', `${TRANSFORM_PROPERTY}-origin`, value)),
       setPosition: ({ top, right, bottom, left }) => {

--- a/index.js
+++ b/index.js
@@ -48,11 +48,12 @@ const materialPackages = [
  *    Ember's module system.
  */
 module.exports = {
-  name: 'ember-material-components-web' /**
+  name: 'ember-material-components-web',
+  /**
    * Invoked at the beginning of the build process, this hook allows us to
    * use the `import()` method to include files from our `vendor` tree into
    * the built app.
-   */,
+   */
   included: function(app) {
     materialPackages.forEach(function(pkg) {
       const pkgBaseName = pkg.name.replace('@material/', '');


### PR DESCRIPTION
Need to safeguard accessing properties of the component in the foundation adapter with `get(this, 'isDestroyed')`, otherwise this can pop up `TypeError: Cannot read property 'notifySelected' of undefined`.