### PR TITLE
Add missing 'aria-disabled' attribute binding

### DIFF
--- a/addon/components/mdc-menu/item.js
+++ b/addon/components/mdc-menu/item.js
@@ -32,7 +32,7 @@ export default Component.extend({
   layout,
   tagName: 'li',
   classNames: ['mdc-list-item'],
-  attributeBindings: ['role', 'tabindex', 'style', ...events],
+  attributeBindings: ['role', 'tabindex', 'aria-disabled', 'style', ...events],
   //endregion
 
   //region Properties

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-material-components-web",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "A suite of Ember components wrapping the official Google material-components-web library",
   "keywords": [
     "components",


### PR DESCRIPTION
This commit adds `aria-disabled` as an attribute binding which is how material-web implements disabled styles for material menu items.

(0.0.41 should probs be Jade Jack Russell Terrier)